### PR TITLE
Check colors on mask and tool changes, not on only every master

### DIFF
--- a/.github/workflows/check_colors.yml
+++ b/.github/workflows/check_colors.yml
@@ -5,9 +5,15 @@ name: Check colors
 
 on:
   push:
-    branches: [ master ]
+    paths:
+      - 'masks/**'
+      - 'tools/canonicialize_masks.py'
+      - '.github/workflows/check_colors.yml'
   pull_request:
-    branches: [ master ]
+    paths:
+      - 'masks/**'
+      - 'tools/canonicialize_masks.py'
+      - '.github/workflows/check_colors.yml'
 
 jobs:
   build:


### PR DESCRIPTION
This allows these checks to run on non-`master` branches as well. It also means the checks don't run spuriously for non-mask or mask tooling check changes.