### PR TITLE
Ensure that masks are not cached in browser in pencil tool

### DIFF
--- a/pencil/server.py
+++ b/pencil/server.py
@@ -73,5 +73,13 @@ def hub():
     return jsonify('\n\n',{"out":str(out.decode("utf-8")), "err": str(err.decode("utf-8") )})
 
 
+@app.after_request
+def add_header(r):
+    r.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    r.headers["Pragma"] = "no-cache"
+    r.headers["Expires"] = "0"
+    r.headers['Cache-Control'] = 'public, max-age=0'
+    return r
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/pencil/static/js_pencil.js
+++ b/pencil/static/js_pencil.js
@@ -142,8 +142,9 @@ $("#download").click((evt)=>{
 })
 
 $("#load").click((evt)=>{
+    var timestamp = new Date().getTime();
     overlayImg = new Image();
-    overlayImg.src = '/masks/'+img_name;
+    overlayImg.src = '/masks/'+img_name+'?t='+timestamp;
     overlayImg.onload = drawAllPaths
     overlayImg.onerror = function(){
         overlayImg = null;


### PR DESCRIPTION
Had the problem where old masked where loaded in the browser, when modifying the .pngs externally.
This fixes this issue, by disabling the browsercache in the development server and appending a timestamp as a query parameter to the image name.