### PR TITLE
Restore completion status badge with badge continually generated from comma10k spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # comma10k
 
-[![Completion Status](https://shields.io/endpoint?url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3DI1&label=Completion%20Status)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)
+[![Completion Status](https://img.shields.io/endpoint?color=%232CC627&url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3Di1)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)
 <!-- If you need to change this because the cells have shifted or a new spreadsheet is used, go to https://cellshield.info -->
 
 It's 10,000 PNGs of real driving captured from the comma fleet. It's MIT license, no academic only restrictions or anything.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # comma10k
 
-[⌛ Check Completion Status Here!](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=1040545508&range=I1)
+[![Completion Status](https://shields.io/endpoint?url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3DI1&label=Completion%20Status)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)
+<!-- If you need to change this because the cells have shifted or a new spreadsheet is used, go to https://cellshield.info -->
 
 It's 10,000 PNGs of real driving captured from the comma fleet. It's MIT license, no academic only restrictions or anything.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # comma10k
 
-[![Completion Status](https://img.shields.io/endpoint?color=%232CC627&url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3Di1)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)
+[![Completion Status](https://img.shields.io/endpoint?color=%2328B224&label=Completion%20Status&url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3Di1)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)
 <!-- If you need to change this because the cells have shifted or a new spreadsheet is used, go to https://cellshield.info -->
 
 It's 10,000 PNGs of real driving captured from the comma fleet. It's MIT license, no academic only restrictions or anything.


### PR DESCRIPTION
I said I would follow up to #2721 and restore some sort of badge for the comma10k readme eventually.

I followed up on that idea and built https://cellshield.info/ and used it to generate the badge for this PR.

[![Completion Status](https://shields.io/endpoint?url=https%3A%2F%2Fcellshield.info%2Fgs%3FspreadSheetId%3D1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8%26cellRange%3DI1&label=Completion%20Status)](https://docs.google.com/spreadsheets/d/1ZKqku0cAyWY0ELY5L2qsKYYYA2AMGbgAn4p53uoT3v8/edit#gid=0)