### PR TITLE
fix canonicalize_masks.py

### DIFF
--- a/tools/canonicialize_masks.py
+++ b/tools/canonicialize_masks.py
@@ -38,7 +38,7 @@ def get_pr(pattern="^masks\w*/"):
   # Use first file in the PR to determine what dir to use then use this value anywhere the correct folder is needed
   # This assumes all files in the PR are in the same folder so this will break if that's not the case
   global base_dir, colormap
-  base_dir = get_base_dir(response.json()[0]['filename'], pattern=pattern)
+  base_dir = get_base_dir(response.json()[0]['filename'])
   colormap = get_colormap(True, base_dir)
 
   for item in response.json():


### PR DESCRIPTION
fix get_base_dir() call without provided a regex pattern

![image](https://user-images.githubusercontent.com/66435071/210828213-30842729-245c-4534-973d-57742d94d739.png)

tested sucessfuly here:
![image](https://user-images.githubusercontent.com/66435071/210828350-c2ef6f61-23ff-4721-8333-e2d951c37e99.png)
