### PR TITLE
Maximize Space and bump up GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/check_colors_sizes.yml
+++ b/.github/workflows/check_colors_sizes.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master      
+      uses: easimon/maximize-build-space@67afc2d7662c9d296547435e7605cc57a1df46f3      
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/.github/workflows/check_colors_sizes.yml
+++ b/.github/workflows/check_colors_sizes.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master      
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/check_file_location.yml
+++ b/.github/workflows/check_file_location.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master      
+      uses: easimon/maximize-build-space@67afc2d7662c9d296547435e7605cc57a1df46f3      
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/.github/workflows/check_file_location.yml
+++ b/.github/workflows/check_file_location.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master      
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/check_filename.yml
+++ b/.github/workflows/check_filename.yml
@@ -18,9 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master      
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/check_filename.yml
+++ b/.github/workflows/check_filename.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master      
+      uses: easimon/maximize-build-space@67afc2d7662c9d296547435e7605cc57a1df46f3      
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/.github/workflows/check_stat.yml
+++ b/.github/workflows/check_stat.yml
@@ -18,12 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master      
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/check_stat.yml
+++ b/.github/workflows/check_stat.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master      
+      uses: easimon/maximize-build-space@67afc2d7662c9d296547435e7605cc57a1df46f3      
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/dont_modify_imgs.yml
+++ b/.github/workflows/dont_modify_imgs.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master      
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/dont_modify_imgs.yml
+++ b/.github/workflows/dont_modify_imgs.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master      
+      uses: easimon/maximize-build-space@67afc2d7662c9d296547435e7605cc57a1df46f3      
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0


### PR DESCRIPTION
GitHub Actions was failing due to checkout causing an out of space error. 

Added https://github.com/marketplace/actions/maximize-build-disk-space

Using this GitHub Action I've added, the checks will work again. More levers to trade time for more space are available in that action if desired.

Threw in a bump to some versions of other actions to Node 18 and so on.

Closes #3355 which was a test of the GitHub Actions system to see it broken.